### PR TITLE
feat: add validator

### DIFF
--- a/controller/suite_test.go
+++ b/controller/suite_test.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	//+kubebuilder:scaffold:imports
+)
+
+func Test(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "Controller Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+})

--- a/controller/validator.go
+++ b/controller/validator.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+type (
+	// ValidationFunction defines the signature of validation functions that this validator can invoke.
+	ValidationFunction func() *ValidationResult
+
+	// ValidationResult is a struct containing whether a validation passed and what was the error in case that
+	// it didn't pass.
+	ValidationResult struct {
+		Err   error
+		Valid bool
+	}
+)
+
+// Validate evaluates all the validation functions passed as an argument and returns a ValidationResult indicating
+// whether the validation passed or not. In case of one of the functions failing the validation, the process will
+// be interrupted and the error will be returned immediately.
+func Validate(functions ...ValidationFunction) *ValidationResult {
+	for _, function := range functions {
+		result := function()
+		if !result.Valid || result.Err != nil {
+			return result
+		}
+	}
+
+	return &ValidationResult{Valid: true}
+}

--- a/controller/validator_test.go
+++ b/controller/validator_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Validator", func() {
+
+	When("Validate is called", func() {
+		It("should return successfully if no validation functions are passed", func() {
+			result := Validate()
+			Expect(result.Err).NotTo(HaveOccurred())
+			Expect(result.Valid).To(BeTrue())
+		})
+
+		It("should return successfully if all validation functions succeed", func() {
+			result := Validate([]ValidationFunction{
+				func() *ValidationResult {
+					return &ValidationResult{Valid: true}
+				},
+				func() *ValidationResult {
+					return &ValidationResult{Valid: true}
+				},
+			}...)
+			Expect(result.Err).NotTo(HaveOccurred())
+			Expect(result.Valid).To(BeTrue())
+		})
+
+		It("should fail immediately if a validation function fails", func() {
+			result := Validate([]ValidationFunction{
+				func() *ValidationResult {
+					return &ValidationResult{Err: fmt.Errorf("validation failed")}
+				},
+				func() *ValidationResult {
+					return &ValidationResult{Valid: true}
+				},
+			}...)
+			Expect(result.Err).To(HaveOccurred())
+			Expect(result.Err.Error()).To(Equal("validation failed"))
+			Expect(result.Valid).To(BeFalse())
+		})
+	})
+})


### PR DESCRIPTION
This change adds code to define a validator. This validator can be used within an adapter to invoke a set of ValidatiorFunctions, which are functions dedicated to validate the adapter resource.

By calling `Validate`, all the functions passed as an argument will get evaluated and a final ValidationResult will be returned, which can be used to condition the operator behaviour.