### PR TITLE
feat(STONEINTG-692): add predicate to ignore backups

### DIFF
--- a/predicates/backups.go
+++ b/predicates/backups.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2023 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package predicates
+
+import (
+	"github.com/redhat-appstudio/operator-toolkit/utils"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// IgnoreBackups implements a default create predicate function to ignore all create events triggered by backup tools.
+type IgnoreBackups struct {
+	predicate.Funcs
+}
+
+// Create returns false if the object associated with the create event contains any of the expected backup labels.
+// It will return true otherwise.
+func (IgnoreBackups) Create(e event.CreateEvent) bool {
+	return !utils.IsObjectRestoredFromBackup(e.Object)
+}

--- a/predicates/backups_test.go
+++ b/predicates/backups_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2023 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package predicates
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+var _ = Describe("Backups predicate", Ordered, func() {
+	When("when IgnoreBackups predicate is used", func() {
+		It("should process create events for objects without backup labels", func() {
+			contextEvent := event.CreateEvent{Object: &corev1.Pod{}}
+			Expect(IgnoreBackups{}.Create(contextEvent)).To(BeTrue())
+		})
+
+		It("should ignore create events for objects with backup labels", func() {
+			contextEvent := event.CreateEvent{
+				Object: &corev1.Pod{
+					ObjectMeta: v1.ObjectMeta{
+						Labels: map[string]string{"velero.io/backup-name": "foo"},
+					},
+				},
+			}
+			Expect(IgnoreBackups{}.Create(contextEvent)).To(BeFalse())
+		})
+
+		It("should process delete events", func() {
+			contextEvent := event.DeleteEvent{Object: &corev1.Pod{}}
+			Expect(IgnoreBackups{}.Delete(contextEvent)).To(BeTrue())
+		})
+
+		It("should process generic events", func() {
+			contextEvent := event.GenericEvent{Object: &corev1.Pod{}}
+			Expect(IgnoreBackups{}.Generic(contextEvent)).To(BeTrue())
+		})
+
+		It("should process update events", func() {
+			contextEvent := event.CreateEvent{Object: &corev1.Pod{}}
+			Expect(IgnoreBackups{}.Create(contextEvent)).To(BeTrue())
+		})
+	})
+})

--- a/predicates/suite_test.go
+++ b/predicates/suite_test.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2023 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package predicates
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	//+kubebuilder:scaffold:imports
+)
+
+func Test(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "Predicates Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+})

--- a/utils/backups.go
+++ b/utils/backups.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2023 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import "sigs.k8s.io/controller-runtime/pkg/client"
+
+var backupLabels = []string{
+	"velero.io/backup-name",
+	"velero.io/restore-name",
+}
+
+// IsObjectRestoredFromBackup returns whether the object passed as an argument was restored from a backup tool or not.
+func IsObjectRestoredFromBackup(object client.Object) bool {
+	for _, label := range backupLabels {
+		if _, ok := object.GetLabels()[label]; ok {
+			return true
+		}
+	}
+
+	return false
+}

--- a/utils/backups_test.go
+++ b/utils/backups_test.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2023 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("Utils", func() {
+
+	When("IsObjectRestoredFromBackup is called", func() {
+		It("should return false if the object does not contain a backup label", func() {
+			pod := &corev1.Pod{}
+
+			Expect(IsObjectRestoredFromBackup(pod)).To(BeFalse())
+		})
+
+		It("should return true if the object contains a backup label", func() {
+			pod := &corev1.Pod{
+				ObjectMeta: v1.ObjectMeta{
+					Labels: map[string]string{"velero.io/backup-name": "foo"},
+				},
+			}
+
+			Expect(IsObjectRestoredFromBackup(pod)).To(BeTrue())
+		})
+	})
+})

--- a/utils/suite_test.go
+++ b/utils/suite_test.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2023 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	//+kubebuilder:scaffold:imports
+)
+
+func Test(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "Utils Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+})


### PR DESCRIPTION
This is a predicate designed to prevent the reconciliation of resources whenever they are restored by a backup tool. Restored resources will not have a proper status, so we need to ignore their creation as we rely on the status to gate our reconcile operations.