### PR TITLE
feat(RHTAPREL-806): update operator toolkit refrence

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ set of tools and best practices. By leveraging operator-toolkit, you can streaml
 patterns and practices across your projects.
 
 For detailed documentation, guides, and examples, please refer to the
-[project wiki](https://github.com/redhat-appstudio/operator-toolkit/wiki). The wiki serves as a
+[project wiki](https://github.com/konflux-ci/operator-toolkit/wiki). The wiki serves as a
 central resource for comprehensive information on the toolkit's various components and features. It provides detailed
 explanations, code samples, and best practices that will help you effectively utilize the toolkit to construct
 high-quality Kubernetes operators.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/redhat-appstudio/operator-toolkit
+module github.com/konflux-ci/operator-toolkit
 
 go 1.19
 

--- a/predicates/backups.go
+++ b/predicates/backups.go
@@ -17,7 +17,7 @@ limitations under the License.
 package predicates
 
 import (
-	"github.com/redhat-appstudio/operator-toolkit/utils"
+	"github.com/konflux-ci/operator-toolkit/utils"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )


### PR DESCRIPTION
 This commit updates the `operator-toolkit` refrence
 as result of migration to `konflux-ci` from `redhat-appstudio`
 more details parent EPIC:
 https://issues.redhat.com/browse/RHTAPREL-800