### PR TITLE
feat(STONEINTG-1382): add mock client to enable testing k8s client ops

### DIFF
--- a/.github/workflows/gosec.yaml
+++ b/.github/workflows/gosec.yaml
@@ -12,10 +12,10 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   gosec:
     name: Check GO security
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,19 +8,19 @@ on:
 jobs:
   go:
     name: Check sources
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.x
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.19
+          go-version: 1.24
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Cache go modules
         id: cache-mod
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -41,4 +41,4 @@ jobs:
       - name: Run Go Tests
         run: make test
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4

--- a/README.md
+++ b/README.md
@@ -17,3 +17,129 @@ Key Features of Operator Toolkit:
 - Utilities for managing conditions, metrics, and event filtering.
 - Seamless integration with [Operator SDK](https://sdk.operatorframework.io/) and [controller-runtime](https://github.com/kubernetes-sigs/controller-runtime).
 - Extensive documentation and examples.
+
+
+## Testing with Mock Client
+
+The operator-toolkit provides comprehensive mocking capabilities for unit testing. You can mock both loader operations (Get) and all client operations (Create, Update, Patch, Delete).
+
+### Basic Usage
+
+#### Mocking Client Operations
+
+```go
+import (
+    "github.com/konflux-ci/operator-toolkit/loader"
+    "k8s.io/api/core/v1"
+    "k8s.io/apimachinery/pkg/api/errors"
+)
+
+// Mock a Create operation that returns an error
+mockCtx, mockClient := loader.GetMockedContextWithClient(
+    ctx,
+    realK8sClient,
+    []loader.MockData{}, // loader mocks (legacy support)
+    []loader.ClientCallMock{
+        {
+            Operation:  loader.OperationCreate,
+            ObjectType: &v1.Pod{},
+            Err:        errors.NewBadRequest("pod creation failed"),
+        },
+    },
+)
+
+// Now when code calls Create on a Pod, it will return the mocked error
+err := mockClient.Create(mockCtx, myPod)
+// err will be "pod creation failed"
+```
+
+#### Supported Operations
+
+- `OperationCreate` - Mock `client.Create()`
+- `OperationUpdate` - Mock `client.Update()`
+- `OperationPatch` - Mock `client.Patch()`
+- `OperationDelete` - Mock `client.Delete()`
+- `OperationGet` - Mock `client.Get()`
+- `OperationList` - Mock `client.List()`
+- `OperationDeleteAllOf` - Mock `client.DeleteAllOf()`
+
+#### Mocking Status Updates
+
+```go
+mockCtx, mockClient := loader.GetMockedContextWithClient(
+    ctx,
+    realK8sClient,
+    []loader.MockData{},
+    []loader.ClientCallMock{
+        {
+            Operation:       loader.OperationUpdate,
+            ObjectType:      &v1.Pod{},
+            SubResourceName: "status",
+            Err:             errors.NewForbidden(schema.GroupResource{}, "pod", nil),
+        },
+    },
+)
+
+// This will return the mocked error
+err := mockClient.Status().Update(mockCtx, myPod)
+```
+
+#### Combining Loader and Client Mocks
+
+```go
+mockCtx, mockClient := loader.GetMockedContextWithClient(
+    ctx,
+    realK8sClient,
+    []loader.MockData{
+        {
+            ContextKey: loader.ApplicationContextKey,
+            Resource:   myApplication,
+        },
+    },
+    []loader.ClientCallMock{
+        {
+            Operation:  loader.OperationCreate,
+            ObjectType: &v1beta2.IntegrationTestScenario{},
+            Err:        errors.NewServerTimeout("timeout"),
+        },
+    },
+)
+
+// Loader mock works
+app, err := loader.GetMockedResourceAndErrorFromContext(mockCtx, loader.ApplicationContextKey, myApplication)
+
+// Client mock works
+err = mockClient.Create(mockCtx, newScenario)
+```
+
+### Testing Different Object Types
+
+The mock client uses type matching, so you can mock different errors for different resource types:
+
+```go
+mockCtx, mockClient := loader.GetMockedContextWithClient(
+    ctx,
+    realK8sClient,
+    []loader.MockData{},
+    []loader.ClientCallMock{
+        {
+            Operation:  loader.OperationCreate,
+            ObjectType: &v1.Pod{},
+            Err:        errors.NewBadRequest("pod error"),
+        },
+        {
+            Operation:  loader.OperationCreate,
+            ObjectType: &v1.ConfigMap{},
+            Err:        errors.NewConflict(schema.GroupResource{}, "cm", nil),
+        },
+    },
+)
+
+// Each type gets its specific mocked error
+err1 := mockClient.Create(mockCtx, myPod)        // returns "pod error"
+err2 := mockClient.Create(mockCtx, myConfigMap)  // returns conflict error
+```
+
+### Fallback to Real Client
+
+When no mock matches an operation, the real client is used. This allows you to mock only specific operations while letting others proceed normally.

--- a/loader/mock_client.go
+++ b/loader/mock_client.go
@@ -1,0 +1,285 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package loader
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ClientOperation represents the type of client operation to mock
+type ClientOperation string
+
+const (
+	// OperationGet represents a Get operation
+	OperationGet ClientOperation = "get"
+	// OperationList represents a List operation
+	OperationList ClientOperation = "list"
+	// OperationCreate represents a Create operation
+	OperationCreate ClientOperation = "create"
+	// OperationUpdate represents an Update operation
+	OperationUpdate ClientOperation = "update"
+	// OperationPatch represents a Patch operation
+	OperationPatch ClientOperation = "patch"
+	// OperationDelete represents a Delete operation
+	OperationDelete ClientOperation = "delete"
+	// OperationDeleteAllOf represents a DeleteAllOf operation
+	OperationDeleteAllOf ClientOperation = "deleteallof"
+)
+
+// ClientCallMock represents a mocked client call configuration
+type ClientCallMock struct {
+	// Operation is the type of client operation (create, update, etc.)
+	Operation ClientOperation
+	// ObjectType is the type of object this mock applies to (e.g., &v1.Pod{} or &v1.PodList{})
+	// For most operations this should be a client.Object, but for List operations it can be a client.ObjectList
+	ObjectType any
+	// Err is the error to return (if any)
+	Err error
+	// Result is the object to return for Get operations or to use for modifications
+	Result client.Object
+	// SubResourceName is the name of the subresource (e.g., "status")
+	SubResourceName string
+}
+
+// mockClient is a custom client that intercepts operations and returns mocked responses
+type mockClient struct {
+	client.Client
+	mocks   []ClientCallMock
+	context context.Context
+}
+
+// NewMockClient creates a new mock client that wraps the real client
+func NewMockClient(realClient client.Client, ctx context.Context) client.Client {
+	return &mockClient{
+		Client:  realClient,
+		context: ctx,
+	}
+}
+
+// findMock finds a matching mock for the given operation and object type
+func (m *mockClient) findMock(operation ClientOperation, obj client.Object) *ClientCallMock {
+	// Check if there are mocks in the context
+	if value := m.context.Value(mockClientCallsKey); value != nil {
+		if mocks, ok := value.([]ClientCallMock); ok {
+			objType := fmt.Sprintf("%T", obj)
+			for i := range mocks {
+				mock := &mocks[i]
+				if mock.Operation == operation {
+					mockObjType := fmt.Sprintf("%T", mock.ObjectType)
+					if mockObjType == objType {
+						return mock
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// Get implements client.Client
+func (m *mockClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if mock := m.findMock(OperationGet, obj); mock != nil {
+		if mock.Err != nil {
+			return mock.Err
+		}
+		if mock.Result != nil {
+			// Copy the mock result to the object
+			obj.SetName(mock.Result.GetName())
+			obj.SetNamespace(mock.Result.GetNamespace())
+			obj.SetLabels(mock.Result.GetLabels())
+			obj.SetAnnotations(mock.Result.GetAnnotations())
+		}
+		return nil
+	}
+	return m.Client.Get(ctx, key, obj, opts...)
+}
+
+// List implements client.Client
+func (m *mockClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	// For List operations, we need to check the underlying type
+	if value := m.context.Value(mockClientCallsKey); value != nil {
+		if mocks, ok := value.([]ClientCallMock); ok {
+			listType := fmt.Sprintf("%T", list)
+			for i := range mocks {
+				mock := &mocks[i]
+				if mock.Operation == OperationList {
+					mockListType := fmt.Sprintf("%T", mock.ObjectType)
+					if mockListType == listType {
+						if mock.Err != nil {
+							return mock.Err
+						}
+						// For successful List mocks, return empty list or custom result
+						return nil
+					}
+				}
+			}
+		}
+	}
+	return m.Client.List(ctx, list, opts...)
+}
+
+// Create implements client.Client
+func (m *mockClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	if mock := m.findMock(OperationCreate, obj); mock != nil {
+		return mock.Err
+	}
+	return m.Client.Create(ctx, obj, opts...)
+}
+
+// Delete implements client.Client
+func (m *mockClient) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	if mock := m.findMock(OperationDelete, obj); mock != nil {
+		return mock.Err
+	}
+	return m.Client.Delete(ctx, obj, opts...)
+}
+
+// Update implements client.Client
+func (m *mockClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	if mock := m.findMock(OperationUpdate, obj); mock != nil {
+		return mock.Err
+	}
+	return m.Client.Update(ctx, obj, opts...)
+}
+
+// Patch implements client.Client
+func (m *mockClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	if mock := m.findMock(OperationPatch, obj); mock != nil {
+		return mock.Err
+	}
+	return m.Client.Patch(ctx, obj, patch, opts...)
+}
+
+// DeleteAllOf implements client.Client
+func (m *mockClient) DeleteAllOf(ctx context.Context, obj client.Object, opts ...client.DeleteAllOfOption) error {
+	if mock := m.findMock(OperationDeleteAllOf, obj); mock != nil {
+		return mock.Err
+	}
+	return m.Client.DeleteAllOf(ctx, obj, opts...)
+}
+
+// Status implements client.Client
+func (m *mockClient) Status() client.StatusWriter {
+	return &mockStatusWriter{
+		StatusWriter: m.Client.Status(),
+		mockClient:   m,
+	}
+}
+
+// SubResource implements client.Client
+func (m *mockClient) SubResource(subResource string) client.SubResourceClient {
+	return &mockSubResourceClient{
+		SubResourceClient: m.Client.SubResource(subResource),
+		mockClient:        m,
+		subResourceName:   subResource,
+	}
+}
+
+// Scheme implements client.Client
+func (m *mockClient) Scheme() *runtime.Scheme {
+	return m.Client.Scheme()
+}
+
+// RESTMapper implements client.Client
+func (m *mockClient) RESTMapper() meta.RESTMapper {
+	return m.Client.RESTMapper()
+}
+
+// GroupVersionKindFor implements client.Client
+func (m *mockClient) GroupVersionKindFor(obj runtime.Object) (schema.GroupVersionKind, error) {
+	return m.Client.GroupVersionKindFor(obj)
+}
+
+// IsObjectNamespaced implements client.Client
+func (m *mockClient) IsObjectNamespaced(obj runtime.Object) (bool, error) {
+	return m.Client.IsObjectNamespaced(obj)
+}
+
+// mockStatusWriter wraps the status writer to intercept status updates
+type mockStatusWriter struct {
+	client.StatusWriter
+	mockClient *mockClient
+}
+
+// Update implements client.StatusWriter
+func (m *mockStatusWriter) Update(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+	if mock := m.mockClient.findMock(OperationUpdate, obj); mock != nil && mock.SubResourceName == "status" {
+		return mock.Err
+	}
+	return m.StatusWriter.Update(ctx, obj, opts...)
+}
+
+// Patch implements client.StatusWriter
+func (m *mockStatusWriter) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+	if mock := m.mockClient.findMock(OperationPatch, obj); mock != nil && mock.SubResourceName == "status" {
+		return mock.Err
+	}
+	return m.StatusWriter.Patch(ctx, obj, patch, opts...)
+}
+
+// Create implements client.StatusWriter (added in newer versions of controller-runtime)
+func (m *mockStatusWriter) Create(ctx context.Context, obj client.Object, subResource client.Object, opts ...client.SubResourceCreateOption) error {
+	if mock := m.mockClient.findMock(OperationCreate, obj); mock != nil && mock.SubResourceName == "status" {
+		return mock.Err
+	}
+	return m.StatusWriter.Create(ctx, obj, subResource, opts...)
+}
+
+// mockSubResourceClient wraps the subresource client
+type mockSubResourceClient struct {
+	client.SubResourceClient
+	mockClient      *mockClient
+	subResourceName string
+}
+
+// Get implements client.SubResourceClient
+func (m *mockSubResourceClient) Get(ctx context.Context, obj client.Object, subResource client.Object, opts ...client.SubResourceGetOption) error {
+	if mock := m.mockClient.findMock(OperationGet, obj); mock != nil && mock.SubResourceName == m.subResourceName {
+		return mock.Err
+	}
+	return m.SubResourceClient.Get(ctx, obj, subResource, opts...)
+}
+
+// Create implements client.SubResourceClient
+func (m *mockSubResourceClient) Create(ctx context.Context, obj client.Object, subResource client.Object, opts ...client.SubResourceCreateOption) error {
+	if mock := m.mockClient.findMock(OperationCreate, obj); mock != nil && mock.SubResourceName == m.subResourceName {
+		return mock.Err
+	}
+	return m.SubResourceClient.Create(ctx, obj, subResource, opts...)
+}
+
+// Update implements client.SubResourceClient
+func (m *mockSubResourceClient) Update(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+	if mock := m.mockClient.findMock(OperationUpdate, obj); mock != nil && mock.SubResourceName == m.subResourceName {
+		return mock.Err
+	}
+	return m.SubResourceClient.Update(ctx, obj, opts...)
+}
+
+// Patch implements client.SubResourceClient
+func (m *mockSubResourceClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+	if mock := m.mockClient.findMock(OperationPatch, obj); mock != nil && mock.SubResourceName == m.subResourceName {
+		return mock.Err
+	}
+	return m.SubResourceClient.Patch(ctx, obj, patch, opts...)
+}


### PR DESCRIPTION
Implement custom mock client in operator-toolkit to enable mocking of
all Kubernetes client operations (Create, Update, Patch, Delete, Get,
List, DeleteAllOf) during unit testing.

This enhancement allows integration-service and other consumers to test
error paths for client operations, significantly increasing test coverage
for non-loader calls.

Key Changes:
- Created mock_client.go with mockClient implementation that intercepts
  all client.Client interface methods
- Added ClientCallMock structure to define mocked client operations with
  configurable errors and results
- Implemented GetMockedContextWithClient() function to support both
  legacy loader mocks and new client operation mocks
- Added support for Status operations (Status().Update(), Status().Patch())
- Added support for SubResource operations (SubResource().Get/Update/Patch())
- Maintained full backward compatibility with existing GetMockedContext()

Testing:
- Added 18 comprehensive test cases in mock_client_test.go (593 lines)
- Tests cover all CRUD operations, error handling, and edge cases
- Tests verify real client fallback when no mock is configured
- Added integration tests in loader_test.go for combined mock scenarios

Documentation:
- Updated README.md with detailed examples and usage patterns
- Documented all supported operations and mock configurations
- Included examples for Status, SubResource, and multi-type mocking


for more info : [STONEINTG-1382](https://issues.redhat.com/browse/STONEINTG-1382)

Assisted by AI : Cursor 