### PR TITLE
ci: verify codecov workflow

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -4,18 +4,21 @@ on:
     branches:
       - main
 jobs:
-  build-and-deploy:
-    runs-on: ubuntu-20.04
+  coverage:
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
         with:
-          persist-credentials: false
-      - name: Set up Go 1.x
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.18
+          go-version: '1.24'
       - name: Run tests
         run: make test
-      - name: Codecov
-        uses: codecov/codecov-action@v3
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: unit-tests
+          files: cover.out
+          fail_ci_if_error: false

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -41,4 +41,9 @@ jobs:
       - name: Run Go Tests
         run: make test
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: unit-tests
+          files: cover.out
+          fail_ci_if_error: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -14,3 +14,7 @@ coverage:
         patch:
             default:
                 informational: true
+
+flags:
+  unit-tests:
+    carryforward: true


### PR DESCRIPTION
- Update codecov workflow
- Codecov token, unit-tests flag

If not already present, please add CODECOV_TOKEN as a repository secret in GitHub Settings -> Secrets and variables -> Actions. The token can be found in [Codecov](https://app.codecov.io/gh/konflux-ci/operator-toolkit) -> Configure -> Upload Token.